### PR TITLE
feat(docs): add YearCardGlass compound API documentation

### DIFF
--- a/docs/components/YEAR_CARD_GLASS.md
+++ b/docs/components/YEAR_CARD_GLASS.md
@@ -1,0 +1,618 @@
+# YearCardGlass
+
+Year card component with glassmorphism styling for career timeline displays. 100% API compatible
+with compound component patterns.
+
+## Overview
+
+`YearCardGlass` provides a modern card for displaying yearly metrics and statistics with expandable
+details, sparkline visualizations, and insight items. It supports both legacy props-based and
+compound component APIs.
+
+### Key Features
+
+- **Dual API Support** - Legacy props API for quick setup, compound API for full control
+- **Expandable Content** - Click to reveal detailed statistics and insights
+- **Sparkline Visualization** - Mini bar charts for monthly activity trends
+- **Insight Cards** - 7 variants for tips, warnings, highlights, and statistics
+- **Selection State** - Controlled selection for timeline navigation
+- **Glassmorphism** - Backdrop blur, glow effects, CSS variables
+- **Theme Support** - Works with all 3 themes (glass, light, aurora)
+- **Responsive** - Adapts to mobile and desktop viewports
+
+### Browser Compatibility
+
+- Chrome 89+
+- Firefox 87+
+- Safari 14.1+
+- Edge 89+
+
+---
+
+## Installation
+
+```tsx
+import { YearCardGlass, useYearCard } from 'shadcn-glass-ui';
+```
+
+---
+
+## Compound API Reference
+
+### Component Structure
+
+```tsx
+<YearCardGlass.Root
+  isSelected={selected}
+  onSelect={handleSelect}
+  isExpanded={expanded}
+  onExpandedChange={setExpanded}
+>
+  <YearCardGlass.Header>
+    <YearCardGlass.Year>2024</YearCardGlass.Year>
+    <YearCardGlass.Badge emoji="🚀" label="Breakthrough" />
+    <YearCardGlass.Value>1,234 commits</YearCardGlass.Value>
+  </YearCardGlass.Header>
+
+  <YearCardGlass.Progress value={75} gradient="blue" />
+  <YearCardGlass.Sparkline data={monthlyData} height="sm" />
+
+  <YearCardGlass.ExpandedContent>
+    <YearCardGlass.Stats columns={3}>
+      <YearCardGlass.StatItem label="Commits" value="1,234" icon={<GitCommit />} />
+      <YearCardGlass.StatItem label="PRs" value="56" icon={<GitPullRequest />} />
+      <YearCardGlass.StatItem label="Repos" value="12" icon={<FolderGit />} />
+    </YearCardGlass.Stats>
+
+    <YearCardGlass.Insights>
+      <YearCardGlass.InsightItem variant="growth" text="Activity Growth" detail="+47%" />
+    </YearCardGlass.Insights>
+
+    <YearCardGlass.Action onClick={onShowYear}>Show repos from 2024</YearCardGlass.Action>
+  </YearCardGlass.ExpandedContent>
+</YearCardGlass.Root>
+```
+
+### Full Component List
+
+| Component         | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| `Root`            | Context provider with selection and expand state |
+| `Header`          | Header section with chevron indicator            |
+| `Year`            | Year display (styled text)                       |
+| `Badge`           | Emoji + label badge (uses BadgeGlass internally) |
+| `Value`           | Commits/metrics value display                    |
+| `Progress`        | Progress bar (uses ProgressGlass)                |
+| `Sparkline`       | Mini bar chart (uses SparklineGlass)             |
+| `ExpandedContent` | Container for expanded details (auto-hides)      |
+| `Stats`           | Grid container for stat items                    |
+| `StatItem`        | Single stat with label, value, and optional icon |
+| `Insights`        | Container for insight items                      |
+| `InsightItem`     | Single insight (uses InsightCardGlass)           |
+| `Action`          | Action button (uses ButtonGlass)                 |
+
+---
+
+## Props API
+
+### Root Props
+
+| Prop               | Type                          | Default | Description                 |
+| ------------------ | ----------------------------- | ------- | --------------------------- |
+| `isSelected`       | `boolean`                     | `false` | Whether card is selected    |
+| `isExpanded`       | `boolean`                     | `false` | Whether card is expanded    |
+| `onSelect`         | `() => void`                  | -       | Selection callback          |
+| `onExpandedChange` | `(expanded: boolean) => void` | -       | Expand state change handler |
+| `className`        | `string`                      | -       | Custom className            |
+
+### Header Props
+
+| Prop        | Type        | Default | Description      |
+| ----------- | ----------- | ------- | ---------------- |
+| `children`  | `ReactNode` | -       | Header content   |
+| `className` | `string`    | -       | Custom className |
+
+### Year Props
+
+| Prop        | Type        | Default | Description      |
+| ----------- | ----------- | ------- | ---------------- |
+| `children`  | `ReactNode` | -       | Year text        |
+| `className` | `string`    | -       | Custom className |
+
+### Badge Props
+
+| Prop        | Type     | Default | Description      |
+| ----------- | -------- | ------- | ---------------- |
+| `emoji`     | `string` | -       | Emoji icon       |
+| `label`     | `string` | -       | Badge text       |
+| `className` | `string` | -       | Custom className |
+
+### Value Props
+
+| Prop        | Type        | Default | Description      |
+| ----------- | ----------- | ------- | ---------------- |
+| `children`  | `ReactNode` | -       | Value text       |
+| `className` | `string`    | -       | Custom className |
+
+### Progress Props
+
+| Prop        | Type               | Default  | Description      |
+| ----------- | ------------------ | -------- | ---------------- |
+| `value`     | `number`           | -        | Progress (0-100) |
+| `gradient`  | `ProgressGradient` | `'blue'` | Color gradient   |
+| `className` | `string`           | -        | Custom className |
+
+**ProgressGradient options:** `'blue'`, `'emerald'`, `'violet'`, `'amber'`, `'rose'`
+
+### Sparkline Props
+
+| Prop         | Type                   | Default | Description             |
+| ------------ | ---------------------- | ------- | ----------------------- |
+| `data`       | `readonly number[]`    | -       | Array of values         |
+| `labels`     | `readonly string[]`    | -       | X-axis labels           |
+| `showLabels` | `boolean`              | `false` | Show labels below chart |
+| `height`     | `'sm' \| 'md' \| 'lg'` | `'sm'`  | Chart height            |
+| `className`  | `string`               | -       | Custom className        |
+
+### ExpandedContent Props
+
+| Prop        | Type        | Default | Description                 |
+| ----------- | ----------- | ------- | --------------------------- |
+| `children`  | `ReactNode` | -       | Content shown when expanded |
+| `className` | `string`    | -       | Custom className            |
+
+**Note:** This component automatically hides when `isExpanded` is `false`.
+
+### Stats Props
+
+| Prop        | Type        | Default | Description                       |
+| ----------- | ----------- | ------- | --------------------------------- |
+| `children`  | `ReactNode` | -       | StatItem children                 |
+| `columns`   | `number`    | auto    | Grid columns (auto from children) |
+| `className` | `string`    | -       | Custom className                  |
+
+### StatItem Props
+
+| Prop        | Type               | Default | Description      |
+| ----------- | ------------------ | ------- | ---------------- |
+| `label`     | `string`           | -       | Stat label       |
+| `value`     | `string \| number` | -       | Stat value       |
+| `icon`      | `ReactNode`        | -       | Optional icon    |
+| `className` | `string`           | -       | Custom className |
+
+### Insights Props
+
+| Prop        | Type        | Default | Description      |
+| ----------- | ----------- | ------- | ---------------- |
+| `children`  | `ReactNode` | -       | InsightItem list |
+| `className` | `string`    | -       | Custom className |
+
+### InsightItem Props
+
+| Prop        | Type             | Default     | Description      |
+| ----------- | ---------------- | ----------- | ---------------- |
+| `variant`   | `InsightVariant` | `'default'` | Insight style    |
+| `emoji`     | `string`         | -           | Emoji icon       |
+| `text`      | `string`         | -           | Main text        |
+| `detail`    | `string`         | -           | Detail text      |
+| `className` | `string`         | -           | Custom className |
+
+**InsightVariant options:** `'default'`, `'tip'`, `'highlight'`, `'warning'`, `'stat'`, `'growth'`,
+`'decline'`
+
+### Action Props
+
+| Prop        | Type                            | Default | Description      |
+| ----------- | ------------------------------- | ------- | ---------------- |
+| `children`  | `ReactNode`                     | -       | Button text      |
+| `onClick`   | `(e: React.MouseEvent) => void` | -       | Click handler    |
+| `className` | `string`                        | -       | Custom className |
+
+---
+
+## Usage Examples
+
+### Basic Compound API
+
+```tsx
+import { useState } from 'react';
+import { YearCardGlass } from 'shadcn-glass-ui';
+
+function BasicYearCard() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+      <YearCardGlass.Header>
+        <YearCardGlass.Year>2024</YearCardGlass.Year>
+        <YearCardGlass.Badge emoji="🚀" label="Breakthrough" />
+        <YearCardGlass.Value>1,234 commits</YearCardGlass.Value>
+      </YearCardGlass.Header>
+      <YearCardGlass.Progress value={75} gradient="blue" />
+    </YearCardGlass.Root>
+  );
+}
+```
+
+---
+
+### Career Timeline
+
+```tsx
+import { useState } from 'react';
+import { YearCardGlass } from 'shadcn-glass-ui';
+import { GitCommit, GitPullRequest } from 'lucide-react';
+
+function CareerTimeline() {
+  const [expandedYear, setExpandedYear] = useState<number | null>(null);
+
+  const years = [
+    {
+      year: 2024,
+      emoji: '🏆',
+      label: 'Champion',
+      commits: '4,123',
+      progress: 95,
+      gradient: 'amber',
+    },
+    {
+      year: 2023,
+      emoji: '🚀',
+      label: 'Breakthrough',
+      commits: '2,567',
+      progress: 78,
+      gradient: 'violet',
+    },
+    {
+      year: 2022,
+      emoji: '🌱',
+      label: 'Growing',
+      commits: '1,234',
+      progress: 55,
+      gradient: 'emerald',
+    },
+  ];
+
+  return (
+    <div className="space-y-3">
+      {years.map(({ year, emoji, label, commits, progress, gradient }) => (
+        <YearCardGlass.Root
+          key={year}
+          isExpanded={expandedYear === year}
+          onExpandedChange={(expanded) => setExpandedYear(expanded ? year : null)}
+          isSelected={expandedYear === year}
+        >
+          <YearCardGlass.Header>
+            <YearCardGlass.Year>{year}</YearCardGlass.Year>
+            <YearCardGlass.Badge emoji={emoji} label={label} />
+            <YearCardGlass.Value>{commits}</YearCardGlass.Value>
+          </YearCardGlass.Header>
+          <YearCardGlass.Progress value={progress} gradient={gradient} />
+          <YearCardGlass.ExpandedContent>
+            <YearCardGlass.Stats>
+              <YearCardGlass.StatItem label="Commits" value={commits} icon={<GitCommit />} />
+              <YearCardGlass.StatItem label="PRs" value={progress * 2} icon={<GitPullRequest />} />
+            </YearCardGlass.Stats>
+          </YearCardGlass.ExpandedContent>
+        </YearCardGlass.Root>
+      ))}
+    </div>
+  );
+}
+```
+
+---
+
+### With Sparkline Visualization
+
+```tsx
+import { YearCardGlass } from 'shadcn-glass-ui';
+import { GitCommit, GitPullRequest, FolderGit, Star } from 'lucide-react';
+
+function SparklineCard() {
+  const [expanded, setExpanded] = useState(true);
+  const monthlyData = [89, 112, 134, 156, 178, 201, 223, 245, 267, 289, 312, 334];
+  const monthLabels = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  return (
+    <YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+      <YearCardGlass.Header>
+        <YearCardGlass.Year>2024</YearCardGlass.Year>
+        <YearCardGlass.Badge emoji="📊" label="Analytics" />
+        <YearCardGlass.Value>2,345 commits</YearCardGlass.Value>
+      </YearCardGlass.Header>
+
+      {/* Collapsed: mini sparkline next to progress */}
+      <div className="flex items-center gap-2">
+        <YearCardGlass.Progress value={85} gradient="blue" />
+        <YearCardGlass.Sparkline data={monthlyData} height="sm" className="w-20" />
+      </div>
+
+      <YearCardGlass.ExpandedContent>
+        {/* Expanded: full sparkline with labels */}
+        <YearCardGlass.Sparkline
+          data={monthlyData}
+          labels={monthLabels}
+          showLabels
+          height="md"
+          className="w-full"
+        />
+
+        <YearCardGlass.Stats columns={4}>
+          <YearCardGlass.StatItem label="Commits" value="2,345" icon={<GitCommit />} />
+          <YearCardGlass.StatItem label="PRs" value="189" icon={<GitPullRequest />} />
+          <YearCardGlass.StatItem label="Repos" value="15" icon={<FolderGit />} />
+          <YearCardGlass.StatItem label="Stars" value="1.2k" icon={<Star />} />
+        </YearCardGlass.Stats>
+
+        <YearCardGlass.Action onClick={() => console.log('View details')}>
+          View detailed analytics
+        </YearCardGlass.Action>
+      </YearCardGlass.ExpandedContent>
+    </YearCardGlass.Root>
+  );
+}
+```
+
+---
+
+### With Insights
+
+```tsx
+import { YearCardGlass } from 'shadcn-glass-ui';
+
+function InsightsCard() {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+      <YearCardGlass.Header>
+        <YearCardGlass.Year>2024</YearCardGlass.Year>
+        <YearCardGlass.Badge emoji="🔥" label="Record Year" />
+        <YearCardGlass.Value>3,456 commits</YearCardGlass.Value>
+      </YearCardGlass.Header>
+      <YearCardGlass.Progress value={95} gradient="amber" />
+
+      <YearCardGlass.ExpandedContent>
+        <YearCardGlass.Stats columns={3}>
+          <YearCardGlass.StatItem label="Commits" value="3,456" />
+          <YearCardGlass.StatItem label="PRs" value="412" />
+          <YearCardGlass.StatItem label="Repos" value="24" />
+        </YearCardGlass.Stats>
+
+        <YearCardGlass.Insights>
+          <YearCardGlass.InsightItem
+            variant="growth"
+            emoji="📈"
+            text="Activity Growth"
+            detail="+47% from last year"
+          />
+          <YearCardGlass.InsightItem
+            variant="highlight"
+            emoji="🎯"
+            text="Best Month"
+            detail="April: 456 commits"
+          />
+          <YearCardGlass.InsightItem
+            variant="warning"
+            emoji="⚠️"
+            text="Notice"
+            detail="Low activity in December"
+          />
+        </YearCardGlass.Insights>
+
+        <YearCardGlass.Action onClick={() => console.log('Show repos')}>
+          Show repos from 2024
+        </YearCardGlass.Action>
+      </YearCardGlass.ExpandedContent>
+    </YearCardGlass.Root>
+  );
+}
+```
+
+---
+
+### Legacy API (Backward Compatible)
+
+```tsx
+import { YearCardGlass } from 'shadcn-glass-ui';
+
+function LegacyCard() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <YearCardGlass
+      year={2024}
+      emoji="🚀"
+      label="Breakthrough"
+      commits="1,234"
+      progress={75}
+      isExpanded={expanded}
+      gradient="blue"
+      prs={56}
+      repos={12}
+      sparklineData={[89, 112, 134, 156, 178, 201, 223, 245, 267, 289, 312, 334]}
+      insights={[
+        { variant: 'growth', text: 'Activity Growth', detail: '+47% from last year' },
+        { variant: 'highlight', text: 'Best Month', detail: 'April: 456 commits' },
+      ]}
+      onShowYear={() => console.log('Show 2024')}
+      onClick={() => setExpanded(!expanded)}
+    />
+  );
+}
+```
+
+---
+
+## Hook: useYearCard()
+
+Access the YearCardGlass context from any child component:
+
+```tsx
+import { useYearCard } from 'shadcn-glass-ui';
+
+function CustomYearContent() {
+  const {
+    isSelected, // Current selection state
+    isExpanded, // Current expanded state
+    onSelect, // Trigger selection
+    onExpandedChange, // Change expanded state
+  } = useYearCard();
+
+  return (
+    <div>
+      {isExpanded && <p>Card is expanded</p>}
+      {isSelected && <p>Card is selected</p>}
+    </div>
+  );
+}
+```
+
+**Note:** `useYearCardOptional()` is also available for contexts where the provider may not exist.
+
+---
+
+## Migration from Legacy API
+
+### Before (Legacy API)
+
+```tsx
+<YearCardGlass
+  year={2024}
+  emoji="🚀"
+  label="Breakthrough"
+  commits="1,234"
+  progress={75}
+  isExpanded={expanded}
+  prs={56}
+  repos={12}
+  insights={[{ variant: 'growth', text: 'Growth', detail: '+47%' }]}
+  onShowYear={handleShow}
+  onClick={() => setExpanded(!expanded)}
+/>
+```
+
+### After (Compound API)
+
+```tsx
+<YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+  <YearCardGlass.Header>
+    <YearCardGlass.Year>2024</YearCardGlass.Year>
+    <YearCardGlass.Badge emoji="🚀" label="Breakthrough" />
+    <YearCardGlass.Value>1,234 commits</YearCardGlass.Value>
+  </YearCardGlass.Header>
+  <YearCardGlass.Progress value={75} gradient="blue" />
+  <YearCardGlass.ExpandedContent>
+    <YearCardGlass.Stats>
+      <YearCardGlass.StatItem label="PRs" value={56} />
+      <YearCardGlass.StatItem label="Repos" value={12} />
+    </YearCardGlass.Stats>
+    <YearCardGlass.Insights>
+      <YearCardGlass.InsightItem variant="growth" text="Growth" detail="+47%" />
+    </YearCardGlass.Insights>
+    <YearCardGlass.Action onClick={handleShow}>Show repos</YearCardGlass.Action>
+  </YearCardGlass.ExpandedContent>
+</YearCardGlass.Root>
+```
+
+**Benefits of Compound API:**
+
+- Full control over layout and ordering
+- Custom components between sections
+- Conditional rendering of individual parts
+- Better tree-shaking for unused sub-components
+
+---
+
+## CSS Variables
+
+YearCardGlass uses CSS variables for theming:
+
+```css
+:root {
+  --year-card-bg: oklch(var(--glass-bg));
+  --year-card-border: oklch(var(--border));
+  --year-card-selected-border: oklch(var(--primary));
+  --year-card-selected-ring: oklch(var(--primary) / 0.3);
+  --year-card-hover-glow: 0 0 20px oklch(var(--glow-color));
+  --expanded-bg: oklch(var(--surface));
+  --expanded-border: oklch(var(--border-subtle));
+}
+```
+
+---
+
+## Accessibility
+
+### Semantic HTML
+
+- Card uses `role="button"` with `tabIndex={0}`
+- Supports keyboard navigation (Enter/Space to toggle)
+- Uses `aria-expanded` for expand state
+- Uses `aria-selected` for selection state
+
+### Keyboard Navigation
+
+- **Tab:** Navigate between cards
+- **Enter/Space:** Toggle expanded state
+- **Focus:** Visual focus ring on active card
+
+### Screen Readers
+
+- Announces expand/collapse state changes
+- Stat items labeled with semantic text
+- Insight items announce variant and detail
+
+---
+
+## Related Components
+
+- **[SparklineGlass](./SPARKLINE_GLASS.md)** - Bar chart visualization
+- **[ProgressGlass](./PROGRESS_GLASS.md)** - Progress bar with gradients
+- **[InsightCardGlass](./INSIGHT_CARD_GLASS.md)** - Insight display variants
+- **[BadgeGlass](./BADGE_GLASS.md)** - Badge component
+
+---
+
+## Changelog
+
+### v2.1.5 (2025-12-XX)
+
+- Added compound API documentation
+- Added 5 new Storybook stories demonstrating compound patterns
+- Resolves Issue #16
+
+### v2.0.0
+
+- Added compound component API
+- Added `useYearCard` hook
+- Added 13 sub-components
+- Maintained backward compatibility with legacy API
+
+---
+
+## Support
+
+- **GitHub Issues:** [Report bugs](https://github.com/yhooi2/shadcn-glass-ui-library/issues)
+- **Storybook:** [View live examples](https://yhooi2.github.io/shadcn-glass-ui-library/)
+- **Documentation:** [CLAUDE.md](../../CLAUDE.md) for AI assistants
+
+---
+
+## License
+
+MIT License - Part of [shadcn-glass-ui-library](https://github.com/yhooi2/shadcn-glass-ui-library)

--- a/src/components/glass/composite/year-card-glass.stories.tsx
+++ b/src/components/glass/composite/year-card-glass.stories.tsx
@@ -370,3 +370,364 @@ export const CompleteExample: Story = {
     onShowYear: () => console.log('Explore 2024'),
   },
 };
+
+// ========================================
+// COMPOUND API EXAMPLES
+// ========================================
+
+import { useState } from 'react';
+
+// Type for compound API stories (doesn't require legacy props)
+type CompoundStory = StoryObj<Meta<typeof YearCardGlass.Root>>;
+
+// Helper components for compound API demos (declared as proper React components)
+function CompoundAPIBasicDemo() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+      <YearCardGlass.Header>
+        <YearCardGlass.Year>2024</YearCardGlass.Year>
+        <YearCardGlass.Badge emoji="🚀" label="Breakthrough" />
+        <YearCardGlass.Value>1,234 commits</YearCardGlass.Value>
+      </YearCardGlass.Header>
+      <YearCardGlass.Progress value={75} gradient="blue" />
+    </YearCardGlass.Root>
+  );
+}
+
+function CompoundAPITimelineDemo() {
+  const [expandedYear, setExpandedYear] = useState<number | null>(null);
+
+  const years = [
+    {
+      year: 2024,
+      emoji: '🏆',
+      label: 'Champion',
+      commits: '4,123',
+      progress: 95,
+      gradient: 'amber' as const,
+    },
+    {
+      year: 2023,
+      emoji: '🚀',
+      label: 'Breakthrough',
+      commits: '2,567',
+      progress: 78,
+      gradient: 'violet' as const,
+    },
+    {
+      year: 2022,
+      emoji: '🌱',
+      label: 'Growing',
+      commits: '1,234',
+      progress: 55,
+      gradient: 'emerald' as const,
+    },
+  ];
+
+  return (
+    <div className="space-y-3 w-80">
+      {years.map(({ year, emoji, label, commits, progress, gradient }) => (
+        <YearCardGlass.Root
+          key={year}
+          isExpanded={expandedYear === year}
+          onExpandedChange={(expanded) => setExpandedYear(expanded ? year : null)}
+          isSelected={expandedYear === year}
+        >
+          <YearCardGlass.Header>
+            <YearCardGlass.Year>{year}</YearCardGlass.Year>
+            <YearCardGlass.Badge emoji={emoji} label={label} />
+            <YearCardGlass.Value>{commits}</YearCardGlass.Value>
+          </YearCardGlass.Header>
+          <YearCardGlass.Progress value={progress} gradient={gradient} />
+          <YearCardGlass.ExpandedContent>
+            <YearCardGlass.Stats>
+              <YearCardGlass.StatItem
+                label="Commits"
+                value={commits}
+                icon={<GitCommit className="w-4 h-4" />}
+              />
+              <YearCardGlass.StatItem
+                label="PRs"
+                value={Math.floor(progress * 2)}
+                icon={<GitPullRequest className="w-4 h-4" />}
+              />
+            </YearCardGlass.Stats>
+          </YearCardGlass.ExpandedContent>
+        </YearCardGlass.Root>
+      ))}
+    </div>
+  );
+}
+
+function CompoundAPIWithSparklineDemo() {
+  const [expanded, setExpanded] = useState(true);
+  const monthlyData = [89, 112, 134, 156, 178, 201, 223, 245, 267, 289, 312, 334];
+  const monthLabels = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  return (
+    <YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+      <YearCardGlass.Header>
+        <YearCardGlass.Year>2024</YearCardGlass.Year>
+        <YearCardGlass.Badge emoji="📊" label="Analytics" />
+        <YearCardGlass.Value>2,345 commits</YearCardGlass.Value>
+      </YearCardGlass.Header>
+
+      <div className="flex items-center gap-2">
+        <YearCardGlass.Progress value={85} gradient="blue" />
+        <YearCardGlass.Sparkline data={monthlyData} height="sm" className="w-20" />
+      </div>
+
+      <YearCardGlass.ExpandedContent>
+        <YearCardGlass.Sparkline
+          data={monthlyData}
+          labels={monthLabels}
+          showLabels
+          height="md"
+          className="w-full"
+        />
+
+        <YearCardGlass.Stats columns={4}>
+          <YearCardGlass.StatItem
+            label="Commits"
+            value="2,345"
+            icon={<GitCommit className="w-4 h-4" />}
+          />
+          <YearCardGlass.StatItem
+            label="PRs"
+            value="189"
+            icon={<GitPullRequest className="w-4 h-4" />}
+          />
+          <YearCardGlass.StatItem
+            label="Repos"
+            value="15"
+            icon={<FolderGit className="w-4 h-4" />}
+          />
+          <YearCardGlass.StatItem label="Stars" value="1.2k" icon={<Star className="w-4 h-4" />} />
+        </YearCardGlass.Stats>
+
+        <YearCardGlass.Action onClick={() => console.log('View details')}>
+          View detailed analytics
+        </YearCardGlass.Action>
+      </YearCardGlass.ExpandedContent>
+    </YearCardGlass.Root>
+  );
+}
+
+function CompoundAPIWithInsightsDemo() {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+      <YearCardGlass.Header>
+        <YearCardGlass.Year>2024</YearCardGlass.Year>
+        <YearCardGlass.Badge emoji="🔥" label="Record Year" />
+        <YearCardGlass.Value>3,456 commits</YearCardGlass.Value>
+      </YearCardGlass.Header>
+      <YearCardGlass.Progress value={95} gradient="amber" />
+
+      <YearCardGlass.ExpandedContent>
+        <YearCardGlass.Stats columns={3}>
+          <YearCardGlass.StatItem label="Commits" value="3,456" />
+          <YearCardGlass.StatItem label="PRs" value="412" />
+          <YearCardGlass.StatItem label="Repos" value="24" />
+        </YearCardGlass.Stats>
+
+        <YearCardGlass.Insights>
+          <YearCardGlass.InsightItem
+            variant="growth"
+            emoji="📈"
+            text="Activity Growth"
+            detail="+47% from last year"
+          />
+          <YearCardGlass.InsightItem
+            variant="highlight"
+            emoji="🎯"
+            text="Best Month"
+            detail="April: 456 commits"
+          />
+          <YearCardGlass.InsightItem
+            variant="warning"
+            emoji="⚠️"
+            text="Notice"
+            detail="Low activity in December"
+          />
+        </YearCardGlass.Insights>
+
+        <YearCardGlass.Action onClick={() => console.log('Show repos')}>
+          Show repos from 2024
+        </YearCardGlass.Action>
+      </YearCardGlass.ExpandedContent>
+    </YearCardGlass.Root>
+  );
+}
+
+function CompoundAPIInteractiveDemo() {
+  const [selectedYear, setSelectedYear] = useState<number>(2024);
+  const [expandedYear, setExpandedYear] = useState<number | null>(2024);
+
+  const years = [
+    { year: 2024, emoji: '🏆', label: 'Best', commits: '4,123', progress: 95 },
+    { year: 2023, emoji: '🚀', label: 'Growth', commits: '2,567', progress: 78 },
+    { year: 2022, emoji: '🌱', label: 'Start', commits: '1,234', progress: 55 },
+    { year: 2021, emoji: '📚', label: 'Learn', commits: '456', progress: 30 },
+  ];
+
+  return (
+    <div className="space-y-3 w-80">
+      <div className="text-sm text-(--text-muted) mb-2">
+        Selected: <span className="font-semibold text-(--text-primary)">{selectedYear}</span>
+      </div>
+
+      {years.map(({ year, emoji, label, commits, progress }) => (
+        <YearCardGlass.Root
+          key={year}
+          isSelected={selectedYear === year}
+          onSelect={() => setSelectedYear(year)}
+          isExpanded={expandedYear === year}
+          onExpandedChange={(expanded) => setExpandedYear(expanded ? year : null)}
+        >
+          <YearCardGlass.Header>
+            <YearCardGlass.Year>{year}</YearCardGlass.Year>
+            <YearCardGlass.Badge emoji={emoji} label={label} />
+            <YearCardGlass.Value>{commits}</YearCardGlass.Value>
+          </YearCardGlass.Header>
+          <YearCardGlass.Progress
+            value={progress}
+            gradient={selectedYear === year ? 'amber' : 'blue'}
+          />
+          <YearCardGlass.ExpandedContent>
+            <YearCardGlass.Stats columns={2}>
+              <YearCardGlass.StatItem label="Commits" value={commits} />
+              <YearCardGlass.StatItem label="Progress" value={`${progress}%`} />
+            </YearCardGlass.Stats>
+            <YearCardGlass.Action onClick={() => console.log(`View ${year}`)}>
+              View {year} in detail
+            </YearCardGlass.Action>
+          </YearCardGlass.ExpandedContent>
+        </YearCardGlass.Root>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Compound API - Basic Usage
+ * Demonstrates the compound component pattern for full control
+ */
+export const CompoundAPIBasic: CompoundStory = {
+  render: () => <CompoundAPIBasicDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Basic compound API usage showing the minimum required components.
+
+\`\`\`tsx
+<YearCardGlass.Root isExpanded={expanded} onExpandedChange={setExpanded}>
+  <YearCardGlass.Header>
+    <YearCardGlass.Year>2024</YearCardGlass.Year>
+    <YearCardGlass.Badge emoji="🚀" label="Breakthrough" />
+    <YearCardGlass.Value>1,234 commits</YearCardGlass.Value>
+  </YearCardGlass.Header>
+  <YearCardGlass.Progress value={75} gradient="blue" />
+</YearCardGlass.Root>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+/**
+ * Compound API - Timeline Layout
+ * Multiple year cards arranged vertically for career timeline
+ */
+export const CompoundAPITimeline: CompoundStory = {
+  render: () => <CompoundAPITimelineDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Timeline layout with multiple year cards. Only one card can be expanded at a time (accordion pattern).
+
+Uses \`isSelected\` prop to highlight the active year and \`onExpandedChange\` to track which year is expanded.
+        `,
+      },
+    },
+  },
+};
+
+/**
+ * Compound API - With Sparkline and Stats
+ * Full featured card with sparkline visualization and detailed stats
+ */
+export const CompoundAPIWithSparkline: CompoundStory = {
+  render: () => <CompoundAPIWithSparklineDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Full-featured card with sparkline in both collapsed and expanded states.
+
+- **Collapsed**: Shows mini sparkline next to progress bar
+- **Expanded**: Shows full sparkline with month labels and detailed stats
+        `,
+      },
+    },
+  },
+};
+
+/**
+ * Compound API - With Insights
+ * Card with insight items for detailed analysis
+ */
+export const CompoundAPIWithInsights: CompoundStory = {
+  render: () => <CompoundAPIWithInsightsDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Card with InsightItem components for detailed analysis.
+
+Insight variants: \`default\`, \`tip\`, \`highlight\`, \`warning\`, \`stat\`, \`growth\`, \`decline\`
+        `,
+      },
+    },
+  },
+};
+
+/**
+ * Compound API - Interactive Selection
+ * Year selector with controlled selection state
+ */
+export const CompoundAPIInteractive: CompoundStory = {
+  render: () => <CompoundAPIInteractiveDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Interactive year selector with controlled \`isSelected\` and \`isExpanded\` states.
+
+- Click on a card to expand it
+- Selection is tracked separately from expansion
+- Uses \`onSelect\` callback to track selection
+        `,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Add 5 new Storybook stories demonstrating compound API patterns:
  - CompoundAPIBasic: Minimal usage with Root, Header, Year, Badge, Value, Progress
  - CompoundAPITimeline: Career timeline with accordion pattern
  - CompoundAPIWithSparkline: Full stats with sparkline visualization
  - CompoundAPIWithInsights: Insights with growth, highlight, warning variants
  - CompoundAPIInteractive: Year selector with controlled selection state
- Create YEAR_CARD_GLASS.md documentation (530+ lines) with:
  - Full compound API reference (13 sub-components)
  - Props tables for all components
  - 5 usage examples with code snippets
  - Migration guide from legacy API
  - useYearCard hook documentation

## Why
Resolves Issue #16 - User requested documentation for YearCardGlass compound API with usage examples.

## Test plan
- [ ] Verify Storybook stories render correctly: `npm run storybook`
- [ ] Check TypeScript: `npm run typecheck:stories`
- [ ] Verify documentation renders in markdown viewer

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)